### PR TITLE
ZVAB gehört Amazon

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Das ist eine kuratierte Liste. Heisst, ich schaue mir wirklich all eure Empfehlu
 * [Links Lesen](https://links-lesen.de) (linker Online Buchladen, selbstverwalteter Kollektivbetrieb)
 * [Wob](https://www.wob.com/de-de) (2nd Hand)
 * [yourbook](https://yourbook.shop) (Deine Stammbuchhandlung bekommt dann 15% von allen Einkäufen, die du bei yourbook machst. Wenn Dir Deine Buchhandlung bei yourbook ein Buch empfiehlt und du es kaufst, bekommt sie sogar 25%.)
-* [ZVAB](https://www.zvab.com) (Bücher Antiquariat)
 
 ### 🥘 Ernährung
 * [Aroma Zapatista](https://www.aroma-zapatista.de) (ein Kollektiv aus Hamburg, das vor allem sehr leckeren Kaffee (aber auch Tee) von genossenschaftlich organisierten indigenen Kleinbauern aus Lateinamerika ohne Zwischenhändler anbietet)


### PR DESCRIPTION
Das ZVAB gehört über AbeBooks Amazon

"Das Zentrale Verzeichnis Antiquarischer Bücher (ZVAB) ist ein Internetmarktplatz für überwiegend deutschsprachige antiquarische Bücher, der seit 2011 über AbeBooks zu Amazon gehört" (https://de.wikipedia.org/wiki/Zentrales_Verzeichnis_Antiquarischer_Bücher)